### PR TITLE
AIRbar settings

### DIFF
--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -80,7 +80,7 @@ export class IpcHandler {
     // ***AIRBAR - START
     if (studyConfig.trackers.taskTracker?.enabled) {
       // we'll misuse this location here to initialze the settings of the airbar
-      const { setSettings } = await import('@external/main/settings/Settings');
+      const { setSettings } = await import('@external/main/settings/ResearcherSettings');
       setSettings(
         studyConfig.trackers.taskTracker.enabledTaskbar,
         studyConfig.trackers.taskTracker.enabledRetrospection
@@ -159,6 +159,27 @@ export class IpcHandler {
     const settings: Settings = await Settings.findOne({ where: { onlyOneEntityShouldExist: 1 } });
     settings[prop] = value;
     await settings.save();
+
+    // ***AIRBAR - START
+    const { closePlanningWindow, 
+      closeTaskBarWindow, 
+      createPlanningOrTaskbarWindow,
+      reloadTaskBarWindowIfOpen } = await import('@external/main/services/WindowService')
+    if (prop === 'enabledAirbar' && !value) {
+      await closePlanningWindow()
+      await closeTaskBarWindow()
+    } else {
+      await createPlanningOrTaskbarWindow()
+    }
+
+    if (prop === 'enabledAirbarTaskbar' && !value) {
+      await closePlanningWindow()
+    }
+
+    if (prop === 'enableAirbarTaskbarTimeTracking') {
+      reloadTaskBarWindowIfOpen()
+    }
+    // ***AIRBAR - END
   }
 
   private async getSettings(): Promise<Settings> {

--- a/src/electron/electron/ipc/IpcHandler.ts
+++ b/src/electron/electron/ipc/IpcHandler.ts
@@ -79,6 +79,14 @@ export class IpcHandler {
 
     // ***AIRBAR - START
     if (studyConfig.trackers.taskTracker?.enabled) {
+      // we'll misuse this location here to initialze the settings of the airbar
+      const { setSettings } = await import('@external/main/settings/Settings');
+      setSettings(
+        studyConfig.trackers.taskTracker.enabledTaskbar,
+        studyConfig.trackers.taskTracker.enabledRetrospection
+      )
+      
+      // initialize the additional ipc handlers used for the airbar frontend
       const { actions } = await import('@external/main/ipc/IpcHandler'); 
       Object.keys(actions).forEach((action: string) => {
         this.actions[action] = actions[action];

--- a/src/electron/electron/main/entities/Settings.ts
+++ b/src/electron/electron/main/entities/Settings.ts
@@ -31,6 +31,20 @@ export class Settings extends BaseEntity {
   @Column({ type: 'boolean', nullable: false, default: true })
   enabledWorkHours: boolean;
 
+  // ***AIRBAR - START
+  @Column({ type: 'boolean', nullable: false, default: true })
+  enabledAirbar: boolean;
+
+  @Column({ type: 'boolean', nullable: false, default: true })
+  enabledAirbarTaskbar: boolean;
+
+  @Column({ type: 'boolean', nullable: false, default: true })
+  enableAirbarTimeTracking: boolean;
+
+  @Column({ type: 'boolean', nullable: false, default: false })
+  enableAirbarTaskbarTimeTracking: boolean;
+  // ***AIRBAR - END
+
   @Column({ type: 'boolean', nullable: false, default: false })
   onboardingShown: boolean;
 

--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -389,7 +389,7 @@ export class WindowService {
         visible: !!studyConfig.trackers.taskTracker?.enabled,
         click: async () => {
           const { createPlanningViewWindow } = await import('@external/main/services/WindowService')
-          createPlanningViewWindow(true)
+          createPlanningViewWindow()
         }
       },
       // ***AIRBAR - END

--- a/src/electron/electron/main/services/WindowService.ts
+++ b/src/electron/electron/main/services/WindowService.ts
@@ -386,12 +386,24 @@ export class WindowService {
       // ***AIRBAR - START
       {
         label: 'Open Task Planning',
-        visible: !!studyConfig.trackers.taskTracker?.enabled,
+        visible: !!studyConfig.trackers.taskTracker?.enabled && settings.enabledAirbar,
         click: async () => {
           const { createPlanningViewWindow } = await import('@external/main/services/WindowService')
           createPlanningViewWindow()
         }
       },
+      // {
+      //   label: 'Open Taskbar',
+      //   visible:
+      //     !!studyConfig.trackers.taskTracker?.enabled
+      //     && !!studyConfig.trackers.taskTracker?.enabledTaskbar
+      //     && settings.enabledAirbarTaskbar
+      //     && settings.enabledAirbar,
+      //   click: async () => {
+      //     const { createTaskBarWindow } = await import('@external/main/services/WindowService')
+      //     createTaskBarWindow()
+      //   }
+      // },
       // ***AIRBAR - END
       {
         label: 'Open Settings',

--- a/src/electron/shared/StudyConfiguration.ts
+++ b/src/electron/shared/StudyConfiguration.ts
@@ -13,6 +13,8 @@ export interface WindowActivityTrackerConfiguration {
 // ***AIRBAR - START
 export interface TaskTrackerConfiguration {
   enabled: boolean
+  enabledTaskbar: boolean
+  enabledRetrospection: boolean
 }
 // ***AIRBAR - END
 

--- a/src/electron/shared/study.config.ts
+++ b/src/electron/shared/study.config.ts
@@ -17,7 +17,7 @@ const studyConfig: StudyConfiguration = {
     // ***AIRBAR - START
     taskTracker: {
       enabled: true,
-      enabledTaskbar: false,
+      enabledTaskbar: true,
       enabledRetrospection: false // TODO: implement once feature is ready
     },
     // ***AIRBAR - END

--- a/src/electron/shared/study.config.ts
+++ b/src/electron/shared/study.config.ts
@@ -16,7 +16,9 @@ const studyConfig: StudyConfiguration = {
   trackers: {
     // ***AIRBAR - START
     taskTracker: {
-      enabled: true
+      enabled: true,
+      enabledTaskbar: false,
+      enabledRetrospection: false // TODO: implement once feature is ready
     },
     // ***AIRBAR - END
     windowActivityTracker: {

--- a/src/electron/src/router/index.ts
+++ b/src/electron/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory, Router } from 'vue-router';
+import { createRouter, createWebHashHistory, Router } from 'vue-router'
 
 const router: Router = createRouter({
   history: createWebHashHistory(),
@@ -42,6 +42,13 @@ const router: Router = createRouter({
           name: 'About',
           component: () => import('../views/settings/AboutView.vue')
         },
+        // ***AIRBAR - START
+        {
+          path: '/airbar',
+          name: 'Airbar',
+          component: () => import('../views/settings/AirbarView.vue')
+        },
+        // ***AIRBAR - END
         {
           path: '/work-hours',
           name: 'Active Times',
@@ -55,6 +62,6 @@ const router: Router = createRouter({
       component: () => import('../views/DataExportView.vue')
     }
   ]
-});
+})
 
-export default router;
+export default router

--- a/src/electron/src/views/SettingsView.vue
+++ b/src/electron/src/views/SettingsView.vue
@@ -2,7 +2,8 @@
 
 import studyConfig from '../../shared/study.config'
 
-const considerWorkHours = studyConfig.trackers.experienceSamplingTracker.enabledWorkHours;
+const considerWorkHours = studyConfig.trackers.experienceSamplingTracker.enabledWorkHours
+const enabledAirbar = studyConfig.trackers.taskTracker?.enabled;
 
 </script>
 
@@ -13,7 +14,9 @@ const considerWorkHours = studyConfig.trackers.experienceSamplingTracker.enabled
       <ul>
         <li><router-link to="about">About</router-link></li>
         <li v-if="considerWorkHours"><router-link to="work-hours">Active Times</router-link></li>
-        <!-- <li><router-link to="config">App Configuration</router-link></li> -->
+        <!-- ***AIRBAR - START -->
+        <li v-if="enabledAirbar"><router-link to="airbar">AIRbar</router-link></li>
+        <!-- ***AIRBAR - END -->
       </ul>
     </nav>
     <div class="content">

--- a/src/electron/src/views/settings/AirbarView.vue
+++ b/src/electron/src/views/settings/AirbarView.vue
@@ -1,0 +1,107 @@
+<!-- ***AIRBAR - START -->
+<script setup lang="ts">
+
+import { onMounted, ref } from 'vue'
+import typedIpcRenderer from '../../utils/typedIpcRenderer'
+import Switch from '../../components/Switch.vue'
+import { Settings } from '../../../electron/main/entities/Settings'
+
+const isEnabled = ref(true)
+const isEnabledTaskbar = ref(true)
+const isEnabledAirbarTimeTracking = ref(true)
+
+onMounted(async () => {
+  try {
+    const settings = await typedIpcRenderer.invoke('getSettings') as Settings
+    isEnabled.value = settings.enabledAirbar
+    isEnabledTaskbar.value = settings.enabledAirbarTaskbar
+    isEnabledAirbarTimeTracking.value = settings.enableAirbarTimeTracking
+  } catch (error) {
+    console.error('Error getting settings:', error)
+  }
+})
+
+const onChangeAirbarEnabled = async (e: Event) => {
+  const isChecked = (e.target as HTMLInputElement).checked
+  isEnabled.value = isChecked
+
+  try {
+    await typedIpcRenderer.invoke('setSettingsProp', 'enabledAirbar', isChecked)
+  } catch (error) {
+    console.error('Error setting AIRbar enabled:', error)
+  }
+}
+
+const onChangeAirbarTaskbarEnabled = async (e: Event) => {
+  const isChecked = (e.target as HTMLInputElement).checked
+  isEnabledTaskbar.value = isChecked
+
+  try {
+    await typedIpcRenderer.invoke('setSettingsProp', 'enabledAirbarTaskbar', isChecked)
+  } catch (error) {
+    console.error('Error setting AIRbar taskbar enabled:', error)
+  }
+}
+
+const onChangeAirbarTimeTrackingEnabled = async (e: Event) => {
+  const isChecked = (e.target as HTMLInputElement).checked
+  isEnabledAirbarTimeTracking.value = isChecked
+
+  try {
+    await typedIpcRenderer.invoke('setSettingsProp', 'enableAirbarTimeTracking', isChecked)
+  } catch (error) {
+    console.error('Error setting AIRbar time tracking enabled:', error)
+  }
+}
+
+</script>
+
+<template>
+  <div>
+    <article class="prose prose-lg mt-4 mb-5">
+      <h1>
+        <span class="primary-blue">AIRbar Settings</span>
+      </h1>
+      <span>
+        Customize your AIRbar experience.
+      </span>
+    </article>
+
+    <Switch :modelValue="isEnabled" :label="'Enable/disable AIRbar'" :on-change="onChangeAirbarEnabled" />
+
+    <template v-if="isEnabled">
+      <div class="container">
+        <Switch :modelValue="isEnabledTaskbar" :label="'Enable/disable taskbar'"
+          :on-change="onChangeAirbarTaskbarEnabled" />
+        <span class="italic">Enable or disable the always-on-top taskbar window.</span>
+        <Switch :modelValue="isEnabledAirbarTimeTracking" :label="'Enable/disable time tracking'"
+          :on-change="onChangeAirbarTimeTrackingEnabled" />
+        <span class="italic">Enable or disable time tracking for tasks.</span>
+      </div>
+    </template>
+
+  </div>
+</template>
+
+<style lang="less">
+@import '../../styles/index';
+
+.primary-blue {
+  color: @primary-color;
+}
+
+.container {
+  width: 70%;
+  border-top: 1px solid rgb(59 130 246 / 0.5);
+  margin-top: 40px;
+}
+
+.switch-container {
+  padding-top: 40px;
+}
+
+.italic {
+  font-style: italic;
+}
+</style>
+<!-- ***AIRBAR - END -->

--- a/src/electron/src/views/settings/AirbarView.vue
+++ b/src/electron/src/views/settings/AirbarView.vue
@@ -65,7 +65,10 @@ const onChangeAirbarTimeTrackingEnabled = async (e: Event) => {
         <span class="primary-blue">AIRbar Settings</span>
       </h1>
       <span>
-        Customize your AIRbar experience.
+        AIRbar is a task management tool designed to enhance Awareness, Intention and Retrospection (AIR). It let's you
+        define up to three key tasks or goals to commit to each workday. Using AIRbar was shown to boost task
+        completion, sharpen focus and reduce multi-tasking. Learn more about the <a href="https://hasel.dev/airbar"
+          target="_blank">tool and science</a> behind it.
       </span>
     </article>
 
@@ -73,9 +76,9 @@ const onChangeAirbarTimeTrackingEnabled = async (e: Event) => {
 
     <template v-if="isEnabled && enabledTaskBarByResearcher">
       <div class="container">
-        <Switch :modelValue="isEnabledTaskbar" :label="'Enable/disable taskbar'"
+        <Switch :modelValue="isEnabledTaskbar" :label="'Enable/disable Taskbar'"
           :on-change="onChangeAirbarTaskbarEnabled" />
-        <span class="italic">Enable or disable the always-on-top taskbar window.</span>
+        <span class="italic">Enable or disable the always-on-top Taskbar window.</span>
         <Switch :modelValue="isEnabledAirbarTimeTracking" :label="'Enable/disable time tracking'"
           :on-change="onChangeAirbarTimeTrackingEnabled" />
         <span class="italic">Enable or disable time tracking for tasks.</span>

--- a/src/electron/src/views/settings/AirbarView.vue
+++ b/src/electron/src/views/settings/AirbarView.vue
@@ -5,10 +5,12 @@ import { onMounted, ref } from 'vue'
 import typedIpcRenderer from '../../utils/typedIpcRenderer'
 import Switch from '../../components/Switch.vue'
 import { Settings } from '../../../electron/main/entities/Settings'
+import studyConfig from '../../../shared/study.config'
 
 const isEnabled = ref(true)
 const isEnabledTaskbar = ref(true)
 const isEnabledAirbarTimeTracking = ref(true)
+const enabledTaskBarByResearcher = ref(studyConfig.trackers.taskTracker?.enabledTaskbar)
 
 onMounted(async () => {
   try {
@@ -69,7 +71,7 @@ const onChangeAirbarTimeTrackingEnabled = async (e: Event) => {
 
     <Switch :modelValue="isEnabled" :label="'Enable/disable AIRbar'" :on-change="onChangeAirbarEnabled" />
 
-    <template v-if="isEnabled">
+    <template v-if="isEnabled && enabledTaskBarByResearcher">
       <div class="container">
         <Switch :modelValue="isEnabledTaskbar" :label="'Enable/disable taskbar'"
           :on-change="onChangeAirbarTaskbarEnabled" />


### PR DESCRIPTION
this PR comprises the implementation of researcher-specific and user-specific settings for the AIRbar features.

- `trackers.taskTracker.enabled`: if false, the navigation element "AIRbar" is hidden from the user settings page.
- `trackers.taskTracker.enabledTaskbar`: if false, taskbar cannot be opened and user-settings related to taskbar are hidden

![image](https://github.com/user-attachments/assets/91d9677a-e51d-4795-805e-ac6a213d0bc9)
This is the current settings page. @casaout let me know how we should name things (airbar? selfmonitoring? task tracking?) and if you have other inputs/suggestions. 

> PS: The retrospection specific features are not yet implemented yet.
