### PR TITLE
smaller AIRbar-related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 1. Do not edit this fork unless you work at the intersection of Airbar and PersonalAnalytics, use the [upstream repository](https://github.com/HASEL-UZH/PersonalAnalytics) instead.
 2. Maintainers of this fork should sync changes of the upstream repository regularly.
 3. Any deviations from the upstream repository are marked with: `***AIRBAR` in the code.
-4. Exceptions to this rule are added npm packages `@rollup/plugin-alias` and `fs-extra`.
+4. Exceptions to this rule is the added npm package `@rollup/plugin-alias`.
 
 ---
 

--- a/src/electron/electron/main/index.ts
+++ b/src/electron/electron/main/index.ts
@@ -160,6 +160,12 @@ app.whenReady().then(async () => {
 
       powerMonitor.on('suspend', async (): Promise<void> => {
         LOG.debug('The system is going to sleep');
+        // ***AIRBAR - START
+        if (studyConfig.trackers.taskTracker?.enabled) {
+          const { stopCurrentTaskAndTaskActivity } = await import('@external/main/services/TaskService');
+          await stopCurrentTaskAndTaskActivity();
+        }
+        // ***AIRBAR - END
         await Promise.all([
           trackers.stopAllTrackers(),
           UsageDataService.createNewUsageDataEvent(UsageDataEventType.SystemSuspend)
@@ -167,6 +173,13 @@ app.whenReady().then(async () => {
       });
       powerMonitor.on('resume', async (): Promise<void> => {
         LOG.debug('The system is resuming');
+        // ***AIRBAR - START
+        if (studyConfig.trackers.taskTracker?.enabled) {
+          const { taskWidgetRemindToTrackTime, reloadTaskBarWindowIfOpen } = await import('@external/main/services/WindowService');
+          await taskWidgetRemindToTrackTime('SYSTEM_RESUME');
+          await reloadTaskBarWindowIfOpen();
+        }
+        // ***AIRBAR - END
         await Promise.all([
           trackers.resumeAllTrackers(),
           UsageDataService.createNewUsageDataEvent(UsageDataEventType.SystemResume)
@@ -174,6 +187,12 @@ app.whenReady().then(async () => {
       });
       powerMonitor.on('shutdown', async (): Promise<void> => {
         LOG.debug('The system is going to shutdown');
+        // ***AIRBAR - START
+        if (studyConfig.trackers.taskTracker?.enabled) {
+          const { stopCurrentTaskAndTaskActivity } = await import('@external/main/services/TaskService');
+          await stopCurrentTaskAndTaskActivity();
+        }
+        // ***AIRBAR - END
         await Promise.all([
           trackers.stopAllTrackers(),
           UsageDataService.createNewUsageDataEvent(UsageDataEventType.SystemShutdown)
@@ -181,6 +200,13 @@ app.whenReady().then(async () => {
       });
       powerMonitor.on('lock-screen', async (): Promise<void> => {
         LOG.debug('The system is going to lock-screen');
+        // ***AIRBAR - START
+        if (studyConfig.trackers.taskTracker?.enabled) {
+          const { stopCurrentTaskAndTaskActivity } = await import('@external/main/services/TaskService');
+          console.log('Stopping current task and task activity due to system lock');
+          await stopCurrentTaskAndTaskActivity();
+        }
+        // ***AIRBAR - END
         await Promise.all([
           trackers.stopAllTrackers(),
           UsageDataService.createNewUsageDataEvent(UsageDataEventType.SystemLockScreen)
@@ -188,6 +214,13 @@ app.whenReady().then(async () => {
       });
       powerMonitor.on('unlock-screen', async (): Promise<void> => {
         LOG.debug('The system is going to unlock-screen');
+        // ***AIRBAR - START
+        if (studyConfig.trackers.taskTracker?.enabled) {
+          const { taskWidgetRemindToTrackTime, reloadTaskBarWindowIfOpen } = await import('@external/main/services/WindowService');
+          await taskWidgetRemindToTrackTime('SYSTEM_RESUME');
+          await reloadTaskBarWindowIfOpen();
+        }
+        // ***AIRBAR - END
         await Promise.all([
           trackers.resumeAllTrackers(),
           UsageDataService.createNewUsageDataEvent(UsageDataEventType.SystemUnlockScreen)

--- a/src/electron/package-lock.json
+++ b/src/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-analytics",
-  "version": "0.0.40",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-analytics",
-      "version": "0.0.40",
+      "version": "0.4.4",
       "hasInstallScript": true,
       "dependencies": {
         "@rollup/plugin-alias": "^5.1.1",
@@ -15,7 +15,6 @@
         "dompurify": "^3.2.4",
         "electron-log": "^5.1.1",
         "electron-updater": "^6.3.0",
-        "fs-extra": "^11.3.0",
         "jsdom": "^25.0.1",
         "node-schedule": "^2.1.1",
         "typeorm": "^0.3.20",
@@ -6615,6 +6614,7 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -67,7 +67,6 @@
     "dompurify": "^3.2.4",
     "electron-log": "^5.1.1",
     "electron-updater": "^6.3.0",
-    "fs-extra": "^11.3.0",
     "jsdom": "^25.0.1",
     "node-schedule": "^2.1.1",
     "typeorm": "^0.3.20",

--- a/src/electron/src/components/StudyInfo.vue
+++ b/src/electron/src/components/StudyInfo.vue
@@ -24,6 +24,12 @@ defineProps({
           </td>
         </tr>
         <tr>
+          <td class="w-40">License:</td>
+          <td>
+            <span class="license-badge">Research Preview License</span>
+          </td>
+        </tr>
+        <tr>
           <td>Contact:</td>
           <td>{{ studyInfo.contactName }} (<a :href="'mailto:' + studyInfo.contactEmail" target="_blank">{{ studyInfo.contactEmail }}</a>)</td>
         </tr>
@@ -50,5 +56,9 @@ defineProps({
 .subject-badge {
   @apply badge badge-neutral text-white;
   background-color: @primary-color;
+}
+.license-badge {
+  @apply badge badge-neutral text-white;
+  background-color: #666;
 }
 </style>

--- a/src/electron/vite.config.ts
+++ b/src/electron/vite.config.ts
@@ -5,7 +5,6 @@ import vue from '@vitejs/plugin-vue';
 import electron from 'vite-plugin-electron/simple';
 import alias from '@rollup/plugin-alias' // ***AIRBAR 
 import pkg from './package.json';
-import fse from 'fs-extra'; // ***AIRBAR 
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {


### PR DESCRIPTION
- on system shutdown/lock/suspend, task tracking stops, and on resumption a task tracking reminder is shown.
- "Research Preview Licence" batch
- typos and text updates (some of them in the PA.SelfReflection repo)
- task planner now shows up to 9 tasks from the last 30 days.
- on minimize, current task is no longer reset to the first task.
- removed `fs-extra`which is no longer needed with the "git submodule" solution for PA.SelfReflection
