### PR TITLE
Release 0.6.0

### DIFF
--- a/src/electron/package-lock.json
+++ b/src/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-analytics",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-analytics",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@jamescoyle/vue-icon": "^0.1.2",

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-analytics",
   "description": "PersonalAnalytics is a privacy-protecting, open-source self-monitoring software",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "main": "dist-electron/main/index.js",
   "type": "module",
   "author": {


### PR DESCRIPTION
- added new visualization 'Active hours on computer'
- refined Retrospection
- fixed bug when navigating to prior workdays in retrospection